### PR TITLE
fix: Move shebang option as explicit `set` bash option

### DIFF
--- a/fzf-links.tmux
+++ b/fzf-links.tmux
@@ -1,4 +1,6 @@
-#!/usr/bin/env bash -f
+#!/usr/bin/env bash
+
+set -f
 
 # Andrea Alberti, 2024
 


### PR DESCRIPTION
When trying your plugin, I was unable to use it automatically.

After some digging, I found the main script `fzf-links.tmux` return code 127.

It seems that using options in shebang might causes issue on some OS as confirmed by shellcheck error [SC2096](https://www.shellcheck.net/wiki/SC2096).
As you can see in the following screenshot : 
![shellcheck-error](https://github.com/user-attachments/assets/71621ce8-708e-40e3-92c7-ff493031d432)

I'm currently using NixOS and indeed, I ran into this issue.

This PR simply fix the shebang to comply with shellcheck which also fix this issue making your plugin working like a charms.
As you can see in the following screenshot: 
![plugin-working](https://github.com/user-attachments/assets/050a4891-30aa-4da2-a08b-714749e614b4)

## Summary by Sourcery

Bug Fixes:
- Fixes an issue where the script `fzf-links.tmux` would return a non-zero exit code.