### PR TITLE
feat: add support to open files from oxlint linter

### DIFF
--- a/tmux-fzf-links-python-pkg/tmux_fzf_links/default_schemes.py
+++ b/tmux-fzf-links-python-pkg/tmux_fzf_links/default_schemes.py
@@ -101,6 +101,20 @@ code_error_scheme: SchemeEntry = {
 
 # <<< CODE ERROR SCHEME <<<
 
+# >>> OXLINT ERROR SCHEME >>>
+
+oxlint_scheme: SchemeEntry = {
+    "tags": ("code err.", "Python"),
+    "opener": OpenerType.EDITOR,
+    "post_handler": code_error_post_handler,
+    "pre_handler": code_error_pre_handler,
+    # Matches linter output like: [src/foo.ts:6:44]
+    # The column number (e.g. 44) is captured but ignored when opening the file.
+    "regex": [re.compile(r"\[(?P<file>[^\]\s:][^\]\s]*):(?P<line>\d+):\d+\]")],
+}
+
+# <<< OXLINT ERROR SCHEME <<<
+
 # >>> URL SCHEME >>>
 
 url_scheme: SchemeEntry = {
@@ -231,6 +245,7 @@ default_schemes: list[SchemeEntry] = [
     file_scheme,
     git_scheme,
     code_error_scheme,
+    oxlint_scheme,
 ]
 
 __all__ = ["default_schemes"]

--- a/tmux-fzf-links-python-pkg/tmux_fzf_links/default_schemes.py
+++ b/tmux-fzf-links-python-pkg/tmux_fzf_links/default_schemes.py
@@ -104,13 +104,15 @@ code_error_scheme: SchemeEntry = {
 # >>> OXLINT ERROR SCHEME >>>
 
 oxlint_scheme: SchemeEntry = {
-    "tags": ("code err.", "Python"),
+    "tags": ("code err.", "JS/TS"),
     "opener": OpenerType.EDITOR,
     "post_handler": code_error_post_handler,
     "pre_handler": code_error_pre_handler,
-    # Matches linter output like: [src/foo.ts:6:44]
+    # Matches linter output like: [src/foo.ts:6:44] or [src/foo bar.d.ts:6:44]
+    # File paths may contain spaces; [^\]]+ allows any char except the closing bracket.
+    # The regex engine backtracks to split on :line:col at the end.
     # The column number (e.g. 44) is captured but ignored when opening the file.
-    "regex": [re.compile(r"\[(?P<file>[^\]\s:][^\]\s]*):(?P<line>\d+):\d+\]")],
+    "regex": [re.compile(r"\[(?P<file>[^\]]+):(?P<line>\d+):\d+\]")],
 }
 
 # <<< OXLINT ERROR SCHEME <<<


### PR DESCRIPTION
## Summary by Sourcery

Add a new scheme to recognize oxlint linter errors and open the corresponding files in the editor.

New Features:
- Support opening files directly from oxlint linter output entries.

Enhancements:
- Include the oxlint error scheme in the default set of link schemes.

<img width="758" height="195" alt="image" src="https://github.com/user-attachments/assets/214685de-2b15-45aa-9c3b-95a643a0da76" />
