### PR TITLE
fix: normalize tmux 3.4 control-char escaping in load_dynamic_options

### DIFF
--- a/tmux-fzf-links-python-pkg/tmux_fzf_links/configs.py
+++ b/tmux-fzf-links-python-pkg/tmux_fzf_links/configs.py
@@ -134,6 +134,17 @@ class ConfigurationManager:
                 text=True,
                 shell=False,
             )
+            # On some tmux releases (notably 3.4 as shipped by Ubuntu 24.04 in
+            # `tmux 3.4-1ubuntu0.1`) the unit-separator byte we use as the
+            # field delimiter is escaped to the literal 4-character string
+            # `\037` before it reaches stdout. Normalize that back to the
+            # actual byte so the split below still works. On tmux versions
+            # that pass the byte through unchanged this is a no-op.
+            #
+            # Reproducer (no plugin involved):
+            #   $ tmux display-message -p $'A\x1fB' | xxd
+            #   00000000: 415c 3033 3742 0a   # "A\037B\n"
+            result = result.replace("\\037", "\x1f")
             lines = result.split("\x1f")
             fzf_display_options = lines[0] if len(lines) > 0 else ""
             other_colors = lines[1] if len(lines) > 1 else ""


### PR DESCRIPTION
## Summary

On stock tmux 3.4 (e.g. Ubuntu 24.04's `tmux 3.4-1ubuntu0.1`) the unit-separator byte (`\x1f`) used as the field separator in `ConfigurationManager.load_dynamic_options` is escaped to the 4-character literal `\037` before it reaches stdout from `display-message -p`. As a result `result.split("\x1f")` does not split, and the trailing `\037` gets appended to the user's last fzf option. Users hit:

```
fzf-links: fzf failed with exit code 2: unknown option: --no-preview\037
```

The README currently states that tmux 3.4 is supported; this PR makes that claim hold on the affected build.

## Reproducer (no plugin involved)

```
$ tmux -V
tmux 3.4
$ tmux display-message -p $'A\x1fB' | xxd
00000000: 415c 3033 3742 0a    # "A\037B\n"
```

(Reproduced on Ubuntu 24.04 native and on WSL2 Ubuntu 24.04, both with `tmux 3.4-1ubuntu0.1`.)

## Fix

Normalize the escaped form back to the actual byte before splitting:

```python
result = result.replace("\\037", "\x1f")
lines = result.split("\x1f")
```

On tmux versions that pass the byte through unchanged this is a no-op.

## Notes / alternatives considered

- A more general approach would be to decode every `\NNN` octal escape, but the only control byte we deliberately put into the format string is `\x1f`, so the targeted replacement keeps the change minimal and avoids touching legitimate user content.
- Switching to a printable multi-character sentinel (e.g. `__TFL_SEP__`) would also work but is a larger behavioral change.

## Test plan

- [x] `python3 -m compileall` clean on the modified file.
- [x] On `tmux 3.4-1ubuntu0.1` the fzf popup now opens cleanly with the user's `@fzf-links-fzf-display-options` (including `--no-preview`).
- [x] No effect expected on tmux releases that already emit raw `\x1f` (the `replace` finds nothing).


Made with [Cursor](https://cursor.com)

## Summary by Sourcery

Bug Fixes:
- Fix failure to split dynamically loaded options when tmux 3.4 escapes the unit-separator field delimiter, preventing invalid fzf options like '--no-preview\037'.