### PR TITLE
fix: guard against pre-3.10 python interpreters

### DIFF
--- a/fzf-links.tmux
+++ b/fzf-links.tmux
@@ -98,6 +98,16 @@ if python_resolved=$(command -v -- "$python" 2>/dev/null); then
   python="$python_resolved"
 fi
 
+# Guard against pre-3.10 interpreters with a clear diagnostic.
+# A bare command-name that did not resolve stays non-executable here and is
+# handled by the run-time -x check on the bound key instead.
+if [ -x "$python" ]; then
+  ver=$("$python" -c 'import sys; print(".".join(map(str, sys.version_info[:3]))); sys.exit(0 if sys.version_info >= (3, 10) else 1)' 2>/dev/null) || {
+    tmux display-message -d 0 "fzf-links: requires python >= 3.10, found ${ver:-unknown} at $python (set @fzf-links-python)"
+    exit 0
+  }
+fi
+
 # Prebuild a fully quoted command line (safe for /bin/sh in run-shell)
 python_q=$(printf "%q" "$python")
 PYENV="PYTHONPATH=$SCRIPT_DIR/tmux-fzf-links-python-pkg:$python_path"


### PR DESCRIPTION
Adds a load-time check that the resolved Python interpreter is >= 3.10, with a clear diagnostic when it isn't.

When `@fzf-links-python` is unset, the loader resolves whatever `python3` is on `PATH`. On macOS without current Command Line Tools, `/usr/bin/python3` is a real, executable 3.9 interpreter, so the existing run-time `[ -x ]` check (`fzf-links.tmux:122`) passes. The user then gets an opaque `SyntaxError` from deep inside `__main__.py` (the package uses `match`/`case` and declares `python_requires=">=3.10"` in `setup.py:27`), with no hint about the cause.

The load-time `command -v` resolution is a perfectly reasonable, the version detection just fixes a minor paper cut/confusion.

## Changes

- Inserts a version guard immediately after interpreter resolution, before the key is bound.
- The `[ -x "$python" ]` gate means a bare command-name that did not resolve (e.g. `python3` when nothing is found) stays non-executable and falls through to the existing run-time message `fzf-links: no executable python found at: …`. Missing and too-old report distinct, accurate diagnostics.
- On the common modern path, `&&` short-circuits before the version-print call, so this costs one `python` startup at tmux server init.
- The message follows the existing `tmux display-message -d 0 "fzf-links: …"` convention and exits without binding the key, matching the run-time guard. The `(set @fzf-links-python)` hint points at the override reporters have used as a workaround.

## Testing

No automated tests exist in the repo, so I verified manually from a tmux session:

- **Too old, clear message**—`tmux set -g @fzf-links-python /usr/bin/false` (executable, version check fails), then `tmux source-file fzf-links.tmux` reports `fzf-links: requires python >= 3.10, found unknown at /usr/bin/false (set @fzf-links-python)`.
- **Missing keeps its own message**—`@fzf-links-python /does/not/exist`: guard is skipped (`[ -x ]` false), key binds, pressing it surfaces the existing no-executable message.
- **Modern unaffected**—with the override unset, the key binds and the picker works as before.

## References

- #6—reporter hit a related version mismatch on macOS. Note that issue's actual failure (`typing.override` requiring 3.12) is separate from this 3.10 guard, so this does not fully resolve it.

## Summary by Sourcery

Bug Fixes:
- Prevent opaque runtime SyntaxError by checking that the resolved Python interpreter is at least version 3.10 before binding the tmux key.