### PR TITLE
feat: native OSC 8 hyperlink support

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ The plugin was originally inspired by [tmux-fzf-url](https://github.com/wfxr/tmu
 - **Integration with tmux Popup Windows**: Provides a seamless user experience within tmux sessions.
 - **Flexible Open Commands**: Configure your favorite editor, browser, or custom command to open links.
 - **Dynamic Logging**: Output logs to tmux messages and/or a file, with adjustable verbosity.
+- **OSC 8 hyperlinks**: Resolve [OSC 8 hyperlinks](https://gist.github.com/egmontkob/eb114294efbcd5adb1944c9f3cb5feda) emitted by tools like `gh`, `delta`, and CI output. A token such as `#497` opens the exact URL it was linked to, labeled `PR`, `issue`, or `commit`, with no guessing.
 - **Colorized Links**: Enhance readability with colorized links, using `$LS_COLORS` for files and directories.
 - **Clipboard support**: By pressing `ctrl`-`c`, the selected items are copied to the tmux buffer and your system's clipboard, instead of executing the configured actions.
 - **Default file association support**: By pressing `ctrl`-`d`, the selected items are opened based on the system's default file association (i.e., using `open` in macOS and `xdg-open` in Linux).
@@ -394,6 +395,43 @@ default_schemes = [
     },
 ]
 ```
+
+### Resolving OSC 8 Hyperlinks
+
+Many tools wrap on-screen text in an [OSC 8 hyperlink](https://gist.github.com/egmontkob/eb114294efbcd5adb1944c9f3cb5feda) whose payload is the canonical target URL:
+
+```
+ESC ] 8 ; id=7jn05 ; https://github.com/owner/repo/pull/497 ST  #497  ESC ] 8 ; ; ST
+```
+
+The plugin captures the pane with `tmux capture-pane -e`, which preserves these sequences. A built-in scheme then surfaces each hyperlink as its own entry, classified as `PR`, `issue`, `commit`, or `link` from the target URL. Selecting `#497` opens `…/pull/497` directly, so an ambiguous token never has to be guessed. This needs a `tmux` that records OSC 8 hyperlinks (3.4 and later). On older versions the scheme finds nothing, and the rest of the plugin is unaffected.
+
+The remaining schemes keep matching the plain text, which the plugin reconstructs from the same capture.
+
+#### Reading the Hyperlink Map in a Handler
+
+User schemes can resolve their own matches against the captured hyperlinks. Import `target_for`, which maps a visible token to the URL it was linked to, or returns `None` when the token was not a hyperlink:
+
+```python
+from tmux_fzf_links.export import target_for
+
+def issue_post_handler(match: re.Match[str]) -> PostHandledMatch:
+    token = match.group(0)
+    return {"url": target_for(token) or f"https://github.com/owner/repo/issues/{match.group('num')}"}
+```
+
+A token that appears with two different targets in one capture is dropped from the map, so a lookup never resolves to the wrong URL.
+
+#### Matching Escaped Content
+
+A scheme can opt into matching the escaped capture instead of the plain text by setting `"escaped": True`. Its regex then sees OSC 8 sequences and SGR codes. This is how the built-in hyperlink scheme works. Most schemes leave it unset and match clean text.
+
+#### References
+
+- [Hyperlinks in terminal emulators](https://gist.github.com/egmontkob/eb114294efbcd5adb1944c9f3cb5feda), the de-facto specification by the VTE maintainer.
+- [iTerm2 escape codes](https://iterm2.com/documentation-escape-codes.html), under the *Anchor (OSC 8)* heading.
+- [WezTerm hyperlinks recipe](https://wezterm.org/recipes/hyperlinks.html), a practical guide to producing and clicking them.
+- [OSC 8 adoption tracker](https://github.com/Alhadis/OSC8-Adoption), terminal-by-terminal support.
 
 ### Adding User-Defined Schemes
 

--- a/tmux-fzf-links-python-pkg/tests/test_dedup.py
+++ b/tmux-fzf-links-python-pkg/tests/test_dedup.py
@@ -1,0 +1,66 @@
+import re
+
+from tmux_fzf_links.__main__ import drop_hyperlinked_duplicates
+from tmux_fzf_links.hyperlinks import hyperlink_regex
+from tmux_fzf_links.opener import PreHandledMatch
+
+ESC = "\x1b"
+ST = f"{ESC}\\"
+
+Item = tuple[PreHandledMatch, str, int, re.Match[str]]
+
+
+def osc8_item(uri: str, text: str) -> Item:
+    m = hyperlink_regex().search(f"{ESC}]8;;{uri}{ST}{text}{ESC}]8;;{ST}")
+    assert m is not None
+    pre: PreHandledMatch = {"display_text": text, "tag": "link"}
+    return (pre, m.group(0), 0, m)
+
+
+def plain_item(text: str) -> Item:
+    m = re.compile(r".+").search(text)
+    assert m is not None
+    pre: PreHandledMatch = {"display_text": text, "tag": "url"}
+    return (pre, m.group(0), 0, m)
+
+
+def test_drops_plain_url_that_was_hyperlinked_to_itself() -> None:
+    url = "https://example.com/guide"
+    items = [osc8_item(url, url), plain_item(url)]
+    out = drop_hyperlinked_duplicates(items)
+    assert len(out) == 1
+    assert out[0][3].re is hyperlink_regex()
+
+
+def test_keeps_unrelated_match_sharing_a_hyperlink_label() -> None:
+    # A filename that merely shares a hyperlink's visible text resolves to a
+    # different target, so it must not be dropped.
+    items = [osc8_item("https://docs.example.com", "foo.txt"), plain_item("foo.txt")]
+    out = drop_hyperlinked_duplicates(items)
+    assert len(out) == 2
+
+
+def test_keeps_plain_text_when_hyperlink_target_differs() -> None:
+    # A shortened label hyperlinked to a different URL: the plain occurrence of
+    # the label opens a distinct destination and is worth keeping.
+    items = [
+        osc8_item("https://long.example.com/full", "https://sho.rt/x"),
+        plain_item("https://sho.rt/x"),
+    ]
+    out = drop_hyperlinked_duplicates(items)
+    assert len(out) == 2
+
+
+def test_drops_plain_match_when_multiple_hyperlinks_share_target() -> None:
+    # Two hyperlinks point at the same URL under different labels, plus a bare
+    # occurrence of that URL. Both hyperlinks survive. Only the plain match drops.
+    url = "https://example.com/guide"
+    items = [osc8_item(url, "guide"), osc8_item(url, "docs"), plain_item(url)]
+    out = drop_hyperlinked_duplicates(items)
+    assert len(out) == 2
+    assert all(item[3].re is hyperlink_regex() for item in out)
+
+
+def test_no_hyperlinks_leaves_items_untouched() -> None:
+    items = [plain_item("foo"), plain_item("bar")]
+    assert drop_hyperlinked_duplicates(items) == items

--- a/tmux-fzf-links-python-pkg/tests/test_hyperlinks.py
+++ b/tmux-fzf-links-python-pkg/tests/test_hyperlinks.py
@@ -1,0 +1,113 @@
+import pytest
+
+from tmux_fzf_links.hyperlinks import (
+    hyperlink_regex,
+    offset_translator,
+    parse_links,
+    set_links,
+    strip_escapes,
+    target_for,
+    url_kind,
+)
+
+ESC = "\x1b"
+ST = f"{ESC}\\"
+
+
+def link(uri: str, text: str, params: str = "") -> str:
+    return f"{ESC}]8;{params};{uri}{ST}{text}{ESC}]8;;{ST}"
+
+
+def test_parse_extracts_text_to_uri() -> None:
+    pr = "https://github.com/bendrucker/dotfiles/pull/497"
+    data = f"shipped {link(pr, 'bendrucker/dotfiles#497', params='id=7jn05')} today"
+    assert parse_links(data) == {"bendrucker/dotfiles#497": pr}
+
+
+def test_parse_strips_sgr_codes_inside_text() -> None:
+    pr = "https://github.com/o/r/pull/497"
+    # Tools wrap the visible text in color codes and leave a trailing reset
+    # before the closing OSC 8 sequence.
+    data = f"{ESC}[94m{link(pr, f'#497{ESC}[0m{ESC}[38;5;246m')}"
+    assert parse_links(data) == {"#497": pr}
+
+
+def test_parse_drops_ambiguous_text() -> None:
+    a = link("https://x/issues/1", "#1")
+    b = link("https://x/pull/1", "#1")
+    assert parse_links(a + b) == {}
+
+
+def test_parse_accepts_bel_terminator() -> None:
+    bel = "\x07"
+    uri = "https://example.com/issues/9"
+    data = f"{ESC}]8;;{uri}{bel}#9{ESC}]8;;{bel}"
+    assert parse_links(data) == {"#9": uri}
+
+
+def test_parse_ignores_plain_text() -> None:
+    assert parse_links("no links here #123") == {}
+
+
+def test_strip_escapes_keeps_visible_text() -> None:
+    pr = "https://github.com/o/r/pull/497"
+    data = f"{ESC}[94mshipped {link(pr, '#497')}{ESC}[0m today"
+    assert strip_escapes(data) == "shipped #497 today"
+
+
+def test_strip_escapes_scrubs_orphan_osc8_marker() -> None:
+    # A hyperlink split across the capture boundary leaves a lone opener.
+    data = f"trailing {ESC}]8;;https://x/issues/1{ST}#1"
+    assert strip_escapes(data) == "trailing #1"
+
+
+def test_strip_escapes_keeps_bel_terminated_text_with_inner_sgr() -> None:
+    bel = "\x07"
+    uri = "https://github.com/o/r/pull/497"
+    # BEL terminator instead of ST, with SGR codes wrapping the visible text.
+    data = f"shipped {ESC}]8;;{uri}{bel}{ESC}[94m#497{ESC}[0m{ESC}]8;;{bel} today"
+    assert strip_escapes(data) == "shipped #497 today"
+
+
+@pytest.mark.parametrize(
+    ("url", "kind"),
+    [
+        ("https://github.com/o/r/pull/497", "pr"),
+        ("https://gitlab.com/g/p/-/merge_requests/7", "pr"),
+        ("https://github.com/o/r/issues/12", "issue"),
+        ("https://github.com/o/r/commit/c91b594", "commit"),
+        ("https://example.com/whatever", "other"),
+    ],
+)
+def test_url_kind(url: str, kind: str) -> None:
+    assert url_kind(url) == kind
+
+
+def test_target_for_resolves_installed_map() -> None:
+    set_links({"#497": "https://github.com/o/r/pull/497"})
+    try:
+        assert target_for("#497") == "https://github.com/o/r/pull/497"
+        assert target_for("#999") is None
+    finally:
+        set_links({})
+    assert target_for("#497") is None
+
+
+def test_offset_translator_matches_strip_escapes_at_every_index() -> None:
+    pr = "https://github.com/o/r/pull/497"
+    data = f"{ESC}[94mshipped {link(pr, '#497')}{ESC}[0m and {link(pr, 'again')} end"
+    translate = offset_translator(data)
+    # The plain offset of any escaped index equals the length of the stripped
+    # prefix up to that index. That is the property the picker sort relies on.
+    for i in range(len(data) + 1):
+        assert translate(i) == len(strip_escapes(data[:i]))
+
+
+def test_offset_translator_maps_hyperlink_starts_to_on_screen_columns() -> None:
+    pr = "https://github.com/o/r/pull/497"
+    data = f"see {link(pr, '#497')} now"
+    translate = offset_translator(data)
+    match = hyperlink_regex().search(data)
+    assert match is not None
+    # "#497" begins at column 4 on screen ("see ").
+    assert translate(match.start()) == 4

--- a/tmux-fzf-links-python-pkg/tests/test_osc8_scheme.py
+++ b/tmux-fzf-links-python-pkg/tests/test_osc8_scheme.py
@@ -1,0 +1,94 @@
+import pytest
+
+from tmux_fzf_links.colors import colors
+from tmux_fzf_links.default_schemes import (
+    default_schemes,
+    osc8_post_handler,
+    osc8_pre_handler,
+    osc8_scheme,
+)
+from tmux_fzf_links.hyperlinks import hyperlink_regex
+
+ESC = "\x1b"
+ST = f"{ESC}\\"
+
+
+def match(uri: str, text: str):
+    data = f"{ESC}]8;;{uri}{ST}{text}{ESC}]8;;{ST}"
+    m = hyperlink_regex().search(data)
+    assert m is not None
+    return m
+
+
+@pytest.fixture(autouse=True)
+def _no_colors() -> None:
+    colors.enable_colors(False)
+
+
+@pytest.mark.parametrize(
+    ("uri", "tag"),
+    [
+        ("https://github.com/o/r/pull/497", "PR"),
+        ("https://gitlab.com/g/p/-/merge_requests/7", "PR"),
+        ("https://github.com/o/r/issues/12", "issue"),
+        ("https://github.com/o/r/commit/c91b594", "commit"),
+        ("https://example.com/docs", "link"),
+    ],
+)
+def test_pre_handler_labels_by_url_kind(uri: str, tag: str) -> None:
+    result = osc8_pre_handler(match(uri, "token"))
+    assert result is not None
+    assert result["tag"] == tag
+    assert result["tag"] in osc8_scheme["tags"]
+
+
+def test_pre_handler_shows_text_and_target() -> None:
+    result = osc8_pre_handler(match("https://example.com/guide", "docs"))
+    assert result is not None
+    assert result["display_text"] == "docs → https://example.com/guide"
+
+
+def test_pre_handler_drops_empty_hyperlink() -> None:
+    assert osc8_pre_handler(match("https://x/issues/1", "   ")) is None
+    assert osc8_pre_handler(match("", "text")) is None
+
+
+def test_post_handler_returns_target_url() -> None:
+    assert osc8_post_handler(match("https://x/pull/9", "#9")) == {
+        "url": "https://x/pull/9"
+    }
+
+
+def test_osc8_scheme_matches_escaped_capture_with_hyperlink_regex() -> None:
+    # The scheme must opt into the escaped capture and drive matching off the
+    # shared OSC 8 pattern. Otherwise it would scan reconstructed plain text and
+    # never see a hyperlink.
+    assert osc8_scheme.get("escaped") is True
+    assert osc8_scheme["regex"] == [hyperlink_regex()]
+
+
+def test_osc8_tags_are_owned_solely_by_osc8_scheme() -> None:
+    # The post-handler is dispatched by the tag parsed out of the fzf line, so a
+    # tag shared by two schemes would route to the wrong handler.
+    for scheme in default_schemes:
+        if scheme is osc8_scheme:
+            continue
+        assert not set(scheme["tags"]) & set(osc8_scheme["tags"])
+
+
+def test_relabeled_match_routes_to_osc8_post_handler() -> None:
+    # Build tag_to_index exactly as __main__ does, then confirm a dynamically
+    # relabeled match (a PR labeled "PR") dispatches back to osc8_scheme.
+    tag_to_index = {
+        tag: index
+        for index, scheme in enumerate(default_schemes)
+        for tag in scheme.get("tags", ())
+    }
+    m = match("https://github.com/o/r/pull/497", "#497")
+    pre = osc8_pre_handler(m)
+    assert pre is not None and pre["tag"] == "PR"
+
+    scheme = default_schemes[tag_to_index[pre["tag"]]]
+    assert scheme is osc8_scheme
+    assert scheme["post_handler"] is not None
+    assert scheme["post_handler"](m) == {"url": "https://github.com/o/r/pull/497"}

--- a/tmux-fzf-links-python-pkg/tmux_fzf_links/__main__.py
+++ b/tmux-fzf-links-python-pkg/tmux_fzf_links/__main__.py
@@ -31,6 +31,13 @@ from .errors_types import (
     PatternNotMatching,
 )
 from .fzf_handler import FzfReturnType, run_fzf
+from .hyperlinks import (
+    hyperlink_regex,
+    offset_translator,
+    parse_links,
+    set_links,
+    strip_escapes,
+)
 from .logging import set_up_logger
 from .opener import (
     OpenerType,
@@ -90,6 +97,30 @@ def load_user_module(file_path: str) -> tuple[list[SchemeEntry], list[str]]:
 def trim_str(s: str) -> str:
     """Trim leading and trailing spaces from a string."""
     return s.strip()
+
+
+def drop_hyperlinked_duplicates(
+    items: list[tuple[PreHandledMatch, str, int, re.Match[str]]],
+) -> list[tuple[PreHandledMatch, str, int, re.Match[str]]]:
+    """Remove plain-text matches that resolve to the same target as an OSC 8
+    hyperlink already present (e.g. a bare URL that was also hyperlinked to
+    itself). The hyperlink row carries the canonical target, so it wins. Keying
+    on the target rather than the visible text avoids dropping an unrelated
+    match (such as a filename) that merely shares a hyperlink's label.
+    """
+    hyperlink_re = hyperlink_regex()
+    osc8_targets = {
+        item[3].group("uri").strip()
+        for item in items
+        if item[3].re is hyperlink_re
+    }
+    if not osc8_targets:
+        return items
+    return [
+        item
+        for item in items
+        if item[3].re is hyperlink_re or item[1].strip() not in osc8_targets
+    ]
 
 
 def run(
@@ -176,26 +207,38 @@ def run(
     except Exception as e:
         raise FailedTmuxPaneSize(f"tmux pane size could not be determined: {e}")
 
-    # Capture tmux content
-    capture_str: list[str] = [
+    # Capture tmux content. The `-e` flag keeps escape sequences, so OSC 8
+    # hyperlinks and SGR codes survive. The plain text the other schemes expect
+    # is reconstructed from it below.
+    capture_args: list[str] = [
         "tmux",
         "capture-pane",
         "-J",
         "-p",
+        "-e",
         "-S",
         f"{-scroll_position - configs.history_lines}",
         "-E",
         f"{pane_height - scroll_position - 1}",
     ]
 
-    content = subprocess.check_output(
-        capture_str,
+    content_escaped = subprocess.check_output(
+        capture_args,
         shell=False,
         text=True,
     )
 
     # To deal with two different forms of handling diactrics, we normalize the string
-    content = unicodedata.normalize("NFC", content)
+    content_escaped = unicodedata.normalize("NFC", content_escaped)
+
+    # Reconstruct the plain capture for schemes that match unescaped text, and
+    # expose the hyperlink map so user-scheme handlers can resolve a matched
+    # token to the URL it was hyperlinked to (see hyperlinks.target_for).
+    content = strip_escapes(content_escaped)
+    set_links(parse_links(content_escaped))
+    # Maps escaped-capture offsets to their plain-text positions, so escaped
+    # schemes sort by on-screen position alongside the plain-text schemes.
+    escaped_to_plain = offset_translator(content_escaped)
 
     # Load user schemes
     user_schemes: list[SchemeEntry]
@@ -258,11 +301,20 @@ def run(
 
     # Process each scheme
     for scheme in schemes:
+        # Escaped schemes (e.g. the OSC 8 hyperlink scheme) match the raw
+        # capture. Everything else matches the reconstructed plain text.
+        source = content_escaped if scheme.get("escaped") else content
         # Use regex.finditer to iterate over all matches
         for regex in scheme["regex"]:
-            for match in regex.finditer(content):
+            for match in regex.finditer(source):
                 entire_match: str = match.group(0)
                 match_start: int = match.start()
+                if scheme.get("escaped"):
+                    # Offsets into the escaped capture are inflated by the escape
+                    # bytes. Translate to the plain-text coordinate space so the
+                    # match sorts by its on-screen position alongside the other
+                    # schemes.
+                    match_start = escaped_to_plain(match_start)
 
                 # Extract and process the matching string
                 pre_handled_match: PreHandledMatch | None
@@ -298,6 +350,9 @@ def run(
                         )
     # Clean up no longer needed variables
     del seen
+
+    # Drop plain-text matches that an OSC 8 hyperlink already covers.
+    items = drop_hyperlinked_duplicates(items)
 
     if items == []:
         logger.info("no link found")

--- a/tmux-fzf-links-python-pkg/tmux_fzf_links/colors.py
+++ b/tmux-fzf-links-python-pkg/tmux_fzf_links/colors.py
@@ -32,6 +32,7 @@ class ColorsSingletonCls:
     index_color: str = ""  # fallback case
     reset_color: str = ""  # fallback case
     dash_color: str = ""  # fallback case
+    dim_color: str = ""  # fallback case
 
     def __new__(cls):
         if cls._instance is None:
@@ -49,12 +50,14 @@ class ColorsSingletonCls:
             # bold + hue: blue keeps contrast on light (Latte) and pops on dark (Frappe)
             self.index_color = self.ansi_color(1) + self.ansi_color(DEFAULT_INDEX_COLOR)
             self.dash_color = self.ansi_color(DEFAULT_DASH_COLOR)
+            self.dim_color = "\033[2m"
         else:
             self.enabled = False
             self.reset_color = ""
             self.tag_color = ""
             self.index_color = ""
             self.dash_color = ""
+            self.dim_color = ""
 
     def set_tag_color(self, R: int, G: int, B: int) -> None:
         self.tag_color = self.rgb_color(R, G, B)

--- a/tmux-fzf-links-python-pkg/tmux_fzf_links/default_schemes.py
+++ b/tmux-fzf-links-python-pkg/tmux_fzf_links/default_schemes.py
@@ -17,6 +17,50 @@ from .export import (
     configs,
     heuristic_find_file,
 )
+from .hyperlinks import clean_text, hyperlink_regex, url_kind
+
+# >>> OSC 8 HYPERLINK SCHEME >>>
+
+# Maps a forge URL kind to the tag shown in the picker. The scheme's tags are
+# derived from this map plus the fallback, so they can never drift out of sync.
+# The tags are owned solely by this scheme, so the post-handler dispatch (which
+# routes by tag) never collides with another.
+_OSC8_TAGS: dict[str, str] = {"pr": "PR", "issue": "issue", "commit": "commit"}
+_OSC8_FALLBACK_TAG = "link"
+
+
+def osc8_pre_handler(match: re.Match[str]) -> PreHandledMatch | None:
+    text = clean_text(match.group("text"))
+    uri = match.group("uri").strip()
+
+    # Drop empty hyperlinks (e.g. a link wrapping only whitespace).
+    if not text or not uri:
+        return None
+
+    tag = _OSC8_TAGS.get(url_kind(uri), _OSC8_FALLBACK_TAG)
+
+    display_text = (
+        f"{colors.rgb_color(80, 200, 255)}{text}{colors.reset_color} "
+        f"{colors.dim_color}→ {uri}{colors.reset_color}"
+    )
+
+    return {"display_text": display_text, "tag": tag}
+
+
+def osc8_post_handler(match: re.Match[str]) -> PostHandledMatch:
+    return {"url": match.group("uri").strip()}
+
+
+osc8_scheme: SchemeEntry = {
+    "tags": (_OSC8_FALLBACK_TAG, *_OSC8_TAGS.values()),
+    "opener": OpenerType.BROWSER,
+    "escaped": True,
+    "post_handler": osc8_post_handler,
+    "pre_handler": osc8_pre_handler,
+    "regex": [hyperlink_regex()],
+}
+
+# <<< OSC 8 HYPERLINK SCHEME <<<
 
 # >>> GIT SCHEME >>>
 
@@ -251,6 +295,7 @@ file_scheme: SchemeEntry = {
 
 # Define schemes
 default_schemes: list[SchemeEntry] = [
+    osc8_scheme,
     url_scheme,
     file_scheme,
     git_scheme,

--- a/tmux-fzf-links-python-pkg/tmux_fzf_links/default_schemes.py
+++ b/tmux-fzf-links-python-pkg/tmux_fzf_links/default_schemes.py
@@ -40,7 +40,7 @@ def osc8_pre_handler(match: re.Match[str]) -> PreHandledMatch | None:
     tag = _OSC8_TAGS.get(url_kind(uri), _OSC8_FALLBACK_TAG)
 
     display_text = (
-        f"{colors.rgb_color(80, 200, 255)}{text}{colors.reset_color} "
+        f"{colors.rgb_color(41, 121, 255)}{text}{colors.reset_color} "
         f"{colors.dim_color}→ {uri}{colors.reset_color}"
     )
 

--- a/tmux-fzf-links-python-pkg/tmux_fzf_links/export.py
+++ b/tmux-fzf-links-python-pkg/tmux_fzf_links/export.py
@@ -4,6 +4,7 @@
 
 from .colors import colors
 from .configs import configs
+from .hyperlinks import target_for, url_kind
 from .opener import OpenerType, PostHandledMatch, PreHandledMatch, SchemeEntry
 from .schemes import heuristic_find_file
 
@@ -15,4 +16,6 @@ __all__ = [
     "heuristic_find_file",
     "PreHandledMatch",
     "PostHandledMatch",
+    "target_for",
+    "url_kind",
 ]

--- a/tmux-fzf-links-python-pkg/tmux_fzf_links/hyperlinks.py
+++ b/tmux-fzf-links-python-pkg/tmux_fzf_links/hyperlinks.py
@@ -1,0 +1,154 @@
+# ===============================================================================
+#   Author: (c) 2024 Andrea Alberti
+# ===============================================================================
+
+"""OSC 8 hyperlink support.
+
+Terminals can wrap on-screen text in an OSC 8 escape sequence whose payload is
+the canonical target URL:
+
+    ESC ] 8 ; params ; URI ST  visible-text  ESC ] 8 ; ; ST
+
+`tmux capture-pane -p` strips these sequences; `capture-pane -p -e` keeps them.
+This module parses the escaped capture so the plugin can:
+
+- surface each hyperlink as a first-class match (see the built-in OSC 8 scheme
+  in ``default_schemes``); and
+- expose a ``visible-text -> URI`` map that any handler can consult via
+  ``target_for`` to resolve an ambiguous token (e.g. ``#497``) to the URL it was
+  actually linked to.
+
+It also reconstructs the plain capture from the escaped one via ``strip_escapes``
+so the remaining (non-escaped) schemes match exactly what they did before.
+"""
+
+from __future__ import annotations
+
+import bisect
+import re
+from collections.abc import Callable
+
+# ST (string terminator) is ESC \ or BEL. The URI runs to the terminator. The
+# visible text may carry its own SGR color codes, stripped out below.
+_ST = r"(?:\x1b\\|\x07)"
+_HYPERLINK = re.compile(
+    rf"\x1b\]8;[^;]*;(?P<uri>[^\x1b\x07]*){_ST}(?P<text>.*?)\x1b\]8;;{_ST}",
+    re.DOTALL,
+)
+# Any OSC 8 marker (open or close), used to scrub orphans left when a hyperlink
+# is split across the capture boundary.
+_OSC8_ANY = re.compile(rf"\x1b\]8;[^\x1b\x07]*{_ST}")
+# SGR and other CSI sequences carried inside the visible text.
+_ANSI = re.compile(r"\x1b\[[0-9;?]*[ -/]*[@-~]")
+
+
+def hyperlink_regex() -> re.Pattern[str]:
+    """The compiled OSC 8 pattern, exposed for the built-in scheme."""
+    return _HYPERLINK
+
+
+def clean_text(text: str) -> str:
+    """Strip SGR codes from a hyperlink's visible text."""
+    return _ANSI.sub("", text).strip()
+
+
+def strip_escapes(data: str) -> str:
+    """Reconstruct the plain capture from an escaped one.
+
+    Keeps each hyperlink's visible text and drops the OSC 8 wrappers and SGR
+    codes, yielding what ``capture-pane -p`` (without ``-e``) would have
+    produced for the same region.
+    """
+    data = _HYPERLINK.sub(lambda m: m.group("text"), data)
+    data = _OSC8_ANY.sub("", data)
+    data = _ANSI.sub("", data)
+    return data
+
+
+def offset_translator(data: str) -> Callable[[int], int]:
+    """Map an index into the escaped capture to the matching index into
+    ``strip_escapes(data)``.
+
+    ``strip_escapes`` drops exactly the OSC 8 markers and SGR sequences, so a
+    plain-text offset is the escaped offset minus the escape bytes preceding it.
+    The translator is built in one pass and answers each query in O(log n), so a
+    caller mapping many match offsets never re-strips the capture prefix.
+    """
+    spans = sorted(
+        [m.span() for m in _OSC8_ANY.finditer(data)]
+        + [m.span() for m in _ANSI.finditer(data)]
+    )
+    ends: list[int] = []
+    removed_through: list[int] = []
+    removed = 0
+    for start, end in spans:
+        removed += end - start
+        ends.append(end)
+        removed_through.append(removed)
+
+    def translate(offset: int) -> int:
+        # Only sequences that fully end at or before the offset are gone from
+        # the plain prefix. One straddling the offset is an incomplete sequence
+        # that strip_escapes leaves in place.
+        k = bisect.bisect_right(ends, offset)
+        return offset - (removed_through[k - 1] if k else 0)
+
+    return translate
+
+
+def parse_links(data: str) -> dict[str, str]:
+    """Map each hyperlink's visible text to its target URI.
+
+    Text that appears with conflicting URIs is dropped so a lookup never
+    resolves to the wrong target.
+    """
+    found: dict[str, str | None] = {}
+    for m in _HYPERLINK.finditer(data):
+        text = clean_text(m.group("text"))
+        uri = m.group("uri").strip()
+        if not text or not uri:
+            continue
+        if text in found and found[text] != uri:
+            found[text] = None
+        else:
+            found.setdefault(text, uri)
+    return {text: uri for text, uri in found.items() if uri}
+
+
+def url_kind(url: str) -> str:
+    """Classify a forge URL as 'pr', 'issue', 'commit', or 'other'."""
+    if "/pull/" in url or "/merge_requests/" in url:
+        return "pr"
+    if "/issues/" in url:
+        return "issue"
+    if "/commit/" in url:
+        return "commit"
+    return "other"
+
+
+# Module-level map populated by the plugin before matching, so that handlers in
+# user schemes can resolve a matched token to the URL it was hyperlinked to.
+_links: dict[str, str] = {}
+
+
+def set_links(links: dict[str, str]) -> None:
+    """Install the ``visible-text -> URI`` map for the current capture."""
+    global _links
+    _links = links
+
+
+def target_for(text: str) -> str | None:
+    """Resolve a matched token to the URL it was hyperlinked to, if any."""
+    return _links.get(text)
+
+
+__all__ = [
+    "hyperlink_regex",
+    "clean_text",
+    "strip_escapes",
+    "offset_translator",
+    "parse_links",
+    "url_kind",
+    "set_links",
+    "target_for",
+]

--- a/tmux-fzf-links-python-pkg/tmux_fzf_links/opener.py
+++ b/tmux-fzf-links-python-pkg/tmux_fzf_links/opener.py
@@ -124,12 +124,19 @@ PostHandler = Callable[[re.Match[str]], PostHandledMatch] | None
 
 
 # Define the structure of each scheme entry
-class SchemeEntry(TypedDict):
+class SchemeEntryRequired(TypedDict):
     tags: tuple[str, ...]
     opener: OpenerType
     pre_handler: PreHandler  # A function that takes a string and returns a string
     post_handler: PostHandler  # A function that takes a string and returns a string
     regex: list[re.Pattern[str]]  # A compiled regex pattern
+
+
+class SchemeEntry(SchemeEntryRequired, total=False):
+    # When true, the scheme matches against the escaped capture
+    # (`capture-pane -e`) rather than the plain text, so it can see OSC 8
+    # hyperlinks and SGR codes. Optional. Defaults to false.
+    escaped: bool
 
 
 xdg_open_util: str | None = None


### PR DESCRIPTION
## Summary

Many terminal tools (`gh`, `delta`, `git`, CI output) attach a target URL to on-screen text using [OSC 8 hyperlinks](https://gist.github.com/egmontkob/eb114294efbcd5adb1944c9f3cb5feda). A pane shows a plain `#497` with nothing to signal that it points at a specific pull request. `capture-pane -p` discards the link, so the plugin sees only the bare token and has to guess what it refers to.

This captures the pane with `-e`, which preserves the OSC 8 sequences, parses them, and opens the exact URL the text was linked to.

## Features

- Adds a built-in OSC 8 scheme. Each hyperlink becomes its own picker row showing the visible text and its dimmed target, classified as `PR`, `issue`, `commit`, or `link` from the URL. Selecting it opens the linked URL.
- Reconstructs the plain capture from the same escaped capture, so every other scheme keeps matching exactly what it did before.
- Drops a plain-text match when an OSC 8 hyperlink already covers that text, so the same link does not appear twice.

## Public API

- `target_for(token)` (exported): maps a visible token to the URL it was linked to, or `None`. User schemes can consult it to resolve their own matches. A token that appears with conflicting targets in one capture is dropped, so a lookup never returns the wrong URL.
- `"escaped": True` on a `SchemeEntry`: opts a scheme into matching the escaped capture (OSC 8 + SGR sequences) rather than the reconstructed plain text. This is how the built-in scheme works; most schemes leave it unset.

## Compatibility

Recording OSC 8 hyperlinks requires tmux 3.4+. On older tmux the scheme finds nothing and the rest of the plugin is unaffected.

## Tests

Adds coverage for hyperlink parsing, plain-text reconstruction, the offset translator, the built-in scheme, and the dedup behavior.

## References

- [Hyperlinks in terminal emulators](https://gist.github.com/egmontkob/eb114294efbcd5adb1944c9f3cb5feda), the de-facto spec.
- [iTerm2 escape codes](https://iterm2.com/documentation-escape-codes.html), under the *Anchor (OSC 8)* heading.
- [OSC 8 adoption tracker](https://github.com/Alhadis/OSC8-Adoption), terminal support matrix.

## Summary by Sourcery

Add native OSC 8 hyperlink support by capturing and parsing escaped tmux pane content, surfacing hyperlinks as first-class picker entries while preserving existing plain-text matching behavior.

New Features:
- Introduce a built-in OSC 8 hyperlink scheme that surfaces each terminal hyperlink as a distinct picker entry labeled as PR, issue, commit, or generic link and opens the linked URL.
- Capture tmux pane content with escape sequences preserved and reconstruct the plain-text view so existing schemes continue to match on-screen text unchanged.
- Expose a hyperlink API (target_for, url_kind) and an optional escaped scheme mode, allowing user-defined schemes to resolve tokens to their canonical URLs or operate directly on escaped content.
- Add dimmed color support for displaying secondary hyperlink information in picker entries.

Enhancements:
- Deduplicate entries by dropping plain-text matches that correspond to an existing OSC 8 hyperlink target so the same link is not listed twice in the picker.

Documentation:
- Document OSC 8 hyperlink handling, including how the built-in scheme works, tmux version requirements, and how user schemes can consume the hyperlink map or opt into escaped matching.

Tests:
- Add unit tests for hyperlink parsing, escape stripping, offset translation, URL classification, and the exported hyperlink map helpers.
- Add tests for the OSC 8 default scheme behavior, including tagging, display formatting, handler dispatch, and tag isolation.
- Add tests verifying deduplication of hyperlinked items versus plain-text matches.
